### PR TITLE
fix/ci: fix autosync deactivation, add chart auto-updater workflow, reword PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,4 +12,4 @@ _In most cases, you can leave out details about how a change has been made. Code
 
 ## Tests executed on which distribution(s)
 
-- [ ] EKS
+- [ ] EKS (AWS)

--- a/.github/workflows/chart-update.yaml
+++ b/.github/workflows/chart-update.yaml
@@ -1,0 +1,46 @@
+---
+name: "chart-update"
+
+on:
+  schedule:
+  - cron: "0 7 * * 1-5"
+  
+  workflow_dispatch:
+    inputs:
+      update-strategy:
+        description: "Update strategy to use. Valid values are 'patch', 'minor' or 'major'"
+        type: choice
+        options:
+        - "patch"
+        - "minor"
+        - "major"
+        required: true
+      excluded-dependencies:
+        description: "Comma-separated list of dependencies to exclude from the update (i.e. 'dependency1,dependency2,dependency3')"
+        type: string
+        required: false
+        default: ""
+      dry-run:
+        description: "Activate dry-run mode"
+        type: boolean
+        required: false
+        default: true
+
+jobs:
+
+  chart-update-schedule:
+    if: ${{ github.event_name == 'schedule' }}
+    strategy:
+      matrix:
+        update-strategy: ["major", "minor"]
+    uses: camptocamp/devops-stack/.github/workflows/modules-chart-update.yaml@main
+    with:
+      update-strategy: ${{ matrix.update-strategy }}
+  
+  chart-update-manual:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    uses: camptocamp/devops-stack/.github/workflows/modules-chart-update.yaml@main
+    with:
+      update-strategy: ${{ inputs.update-strategy }}
+      excluded-dependencies: ${{ inputs.excluded-dependencies }}
+      dry-run: ${{ inputs.dry-run }}

--- a/README.adoc
+++ b/README.adoc
@@ -136,7 +136,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.2"`
+Default: `"v2.0.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -232,9 +232,9 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
-|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Modules
@@ -277,7 +277,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.2"`
+|`"v2.0.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = devops-stack-module-ebs-csi-driver
 // Document attributes to replace along the document
-:chart-version: 2.17.1
+:aws-ebs-csi-driver-chart-version: 2.17.1
 :original-repo-url: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/96b23f359d859cedc6c88d06a9b61e830f45b3db
 
 A https://devops-stack.io[DevOps Stack] module to deploy an Amazon EBS Container Storage Interface (CSI) driver.
@@ -10,7 +10,7 @@ The EBS CSI Driver chart used by this module is shipped in this repository as we
 [cols="1,1,1",options="autowidth,header"]
 |===
 |Current Chart Version |Original Repository |Default Values
-|*{chart-version}* |{original-repo-url}/charts/aws-ebs-csi-driver[Chart] |{original-repo-url}/charts/aws-ebs-csi-driver/values.yaml[`values.yaml`]
+|*{aws-ebs-csi-driver-chart-version}* |{original-repo-url}/charts/aws-ebs-csi-driver[Chart] |{original-repo-url}/charts/aws-ebs-csi-driver/values.yaml[`values.yaml`]
 |===
 
 == Usage

--- a/charts/ebs-csi-driver/Chart.yaml
+++ b/charts/ebs-csi-driver/Chart.yaml
@@ -4,5 +4,5 @@ name: "aws-ebs-csi-driver"
 version: "0"
 dependencies:
   - name: "aws-ebs-csi-driver"
-    version: "^2"
+    version: "2.17.1"
     repository: "https://kubernetes-sigs.github.io/aws-ebs-csi-driver/"

--- a/main.tf
+++ b/main.tf
@@ -81,10 +81,13 @@ resource "argocd_application" "this" {
     }
 
     sync_policy {
-      automated {
-        prune       = var.app_autosync.prune
-        self_heal   = var.app_autosync.self_heal
-        allow_empty = var.app_autosync.allow_empty
+      dynamic "automated" {
+        for_each = toset(var.app_autosync == { "allow_empty" = tobool(null), "prune" = tobool(null), "self_heal" = tobool(null) } ? [] : [var.app_autosync])
+        content {
+          prune       = automated.value.prune
+          self_heal   = automated.value.self_heal
+          allow_empty = automated.value.allow_empty
+        }
       }
 
       retry {


### PR DESCRIPTION
## Description of the changes

This PR:
- re-adds the support to deactivate the auto-sync, which was broken by the use of dynamic Terraform blocks on the PR #10. This is not a breaking change, because users can still use the old way of passing an empty map to the `app_autosync` variable in order do deactivate the auto-sync.
- adds the workflow that enables the auto-upgrade of the Helm charts.
- does a small rewording of the PR template.

:warning: **Do a _Rebase and merge_**

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] EKS (AWS)
