### PR TITLE
fix!: remove the Argo CD namespace variable and hardcode the Helm release name

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -106,12 +106,6 @@ The following resources are used by this module:
 
 The following input variables are required:
 
-==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-
-Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
-
-Type: `string`
-
 ==== [[input_create_role]] <<input_create_role,create_role>>
 
 Description: Boolean to indicate that the OIDC assumable IAM role should be created. **If passing `iam_role_arn` this should be false, otherwise if you want to create the OIDC assumable IAM role provided by this module, you will need to specify the variable `cluster_oidc_issuer_url`.**
@@ -160,7 +154,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.2.0"`
+Default: `"v2.4.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -201,14 +195,6 @@ Description: IDs of the other modules on which this module depends on.
 Type: `map(string)`
 
 Default: `{}`
-
-==== [[input_name]] <<input_name,name>>
-
-Description: Name used to override the chart name on deployment.
-
-Type: `string`
-
-Default: `"ebs-csi-driver"`
 
 ==== [[input_iam_role_arn]] <<input_iam_role_arn,iam_role_arn>>
 
@@ -256,9 +242,9 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
-|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Modules
@@ -292,12 +278,6 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |`"cluster"`
 |no
 
-|[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|Namespace used by Argo CD where the Application and AppProject resources should be created.
-|`string`
-|n/a
-|yes
-
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -319,7 +299,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.2.0"`
+|`"v2.4.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>
@@ -358,12 +338,6 @@ object({
 |IDs of the other modules on which this module depends on.
 |`map(string)`
 |`{}`
-|no
-
-|[[input_name]] <<input_name,name>>
-|Name used to override the chart name on deployment.
-|`string`
-|`"ebs-csi-driver"`
 |no
 
 |[[input_create_role]] <<input_create_role,create_role>>

--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,6 @@
 locals {
   helm_values = [{
     "aws-ebs-csi-driver" = {
-      nameOverride = var.name
       controller = {
         serviceAccount = {
           annotations = {

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,8 @@ resource "argocd_application" "this" {
       path            = "charts/ebs-csi-driver"
       target_revision = var.target_revision
       helm {
-        values = data.utils_deep_merge_yaml.values.output
+        release_name = "efs-csi-driver"
+        values       = data.utils_deep_merge_yaml.values.output
       }
     }
 

--- a/main.tf
+++ b/main.tf
@@ -6,10 +6,7 @@ resource "argocd_project" "this" {
   count = var.argocd_project == null ? 1 : 0
   metadata {
     name      = var.destination_cluster != "in-cluster" ? "ebs-csi-driver-${var.destination_cluster}" : "ebs-csi-driver"
-    namespace = var.argocd_namespace
-    annotations = {
-      "devops-stack.io/argocd_namespace" = var.argocd_namespace
-    }
+    namespace = "argocd"
   }
 
   spec {
@@ -54,7 +51,7 @@ module "iam_assumable_role_ebs" {
 resource "argocd_application" "this" {
   metadata {
     name      = var.destination_cluster != "in-cluster" ? "ebs-csi-driver-${var.destination_cluster}" : "ebs-csi-driver"
-    namespace = var.argocd_namespace
+    namespace = "argocd"
     labels = merge({
       "application" = "ebs-csi-driver"
       "cluster"     = var.destination_cluster

--- a/variables.tf
+++ b/variables.tf
@@ -67,12 +67,6 @@ variable "dependency_ids" {
 ## Module variables
 #######################
 
-variable "name" {
-  description = "Name used to override the chart name on deployment."
-  type        = string
-  default     = "ebs-csi-driver"
-}
-
 variable "create_role" {
   description = "Boolean to indicate that the OIDC assumable IAM role should be created. **If passing `iam_role_arn` this should be false, otherwise if you want to create the OIDC assumable IAM role provided by this module, you will need to specify the variable `cluster_oidc_issuer_url`.**"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -8,11 +8,6 @@ variable "cluster_name" {
   default     = "cluster"
 }
 
-variable "argocd_namespace" {
-  description = "Namespace used by Argo CD where the Application and AppProject resources should be created."
-  type        = string
-}
-
 variable "argocd_project" {
   description = "Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application."
   type        = string


### PR DESCRIPTION
## Description of the changes

The main changes of this PR are the following:

- **fix!: hardcode the release name to remove the destination cluster**

  I found out that Argo CD passes the name of the application as a value to set the Helm chart. This means that all the templating that used `{ $.Release.Name }` would resolve to the name given to Argo CD application.

  In a multicluster deployment, using a single Argo CD, the names of the applications must be different. We solved that by appending the cluster name to the default application name when deploying on different clusters than `in-cluster`. However, this resulted in multiple problems for deployments that depended on the name of the application being static, so this solves that.

  This is a breaking change because sometimes this requires an application to be deleted and recreated.

- **fix!: remove the ArgoCD namespace variable**

  Since we are hardcoding the namespace variable on all modules, the variable to set the ArgoCD namespace will no longer be needed as well.

:warning: **Do a _Rebase and merge_**

## Breaking change

- [x] Yes (in the module itself): because of the removal of the `argocd_namespace` variable and the fact that overloading the release name can force a recreation of the application.

## Tests executed on which distribution(s)

- [x] EKS (AWS)