### PR TITLE
feat: add variable to set resources with default values

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -76,11 +76,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_null]] <<provider_null,null>> (>= 3)
+
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
-
-- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Modules
 
@@ -154,7 +154,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.4.0"`
+Default: `"v3.1.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -193,6 +193,44 @@ Default:
 Description: IDs of the other modules on which this module depends on.
 
 Type: `map(string)`
+
+Default: `{}`
+
+==== [[input_resources]] <<input_resources,resources>>
+
+Description: Resource limits and requests for aws-ebs-csi-driver's components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values."
+
+NOTE: These are the same values as the defaults on the Helm chart aws-ebs-csi-driver.
+
+Type:
+[source,hcl]
+----
+object({
+
+    controller = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "10m")
+        memory = optional(string, "40Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+    node = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "10m")
+        memory = optional(string, "40Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+  })
+----
 
 Default: `{}`
 
@@ -242,9 +280,9 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
+|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Modules
@@ -299,7 +337,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.4.0"`
+|`"v3.1.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>
@@ -337,6 +375,45 @@ object({
 |[[input_dependency_ids]] <<input_dependency_ids,dependency_ids>>
 |IDs of the other modules on which this module depends on.
 |`map(string)`
+|`{}`
+|no
+
+|[[input_resources]] <<input_resources,resources>>
+|Resource limits and requests for aws-ebs-csi-driver's components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values."
+
+NOTE: These are the same values as the defaults on the Helm chart aws-ebs-csi-driver.
+
+|
+
+[source]
+----
+object({
+
+    controller = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "10m")
+        memory = optional(string, "40Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+    node = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "10m")
+        memory = optional(string, "40Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+  })
+----
+
 |`{}`
 |no
 

--- a/locals.tf
+++ b/locals.tf
@@ -7,6 +7,16 @@ locals {
             "eks.amazonaws.com/role-arn" = var.iam_role_arn != null ? var.iam_role_arn : module.iam_assumable_role_ebs.iam_role_arn
           }
         }
+        resources = {
+          requests = { for k, v in var.resources.controller.requests : k => v if v != null }
+          limits   = { for k, v in var.resources.controller.limits : k => v if v != null }
+        }
+      }
+      node = {
+        resources = {
+          requests = { for k, v in var.resources.node.requests : k => v if v != null }
+          limits   = { for k, v in var.resources.node.limits : k => v if v != null }
+        }
       }
     }
   }]

--- a/variables.tf
+++ b/variables.tf
@@ -62,6 +62,40 @@ variable "dependency_ids" {
 ## Module variables
 #######################
 
+variable "resources" {
+  description = <<-EOT
+    Resource limits and requests for aws-ebs-csi-driver's components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values."
+
+    NOTE: These are the same values as the defaults on the Helm chart aws-ebs-csi-driver.
+  EOT
+  type = object({
+
+    controller = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "10m")
+        memory = optional(string, "40Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+    node = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "10m")
+        memory = optional(string, "40Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "256Mi")
+      }), {})
+    }), {})
+
+  })
+  default = {}
+}
+
 variable "create_role" {
   description = "Boolean to indicate that the OIDC assumable IAM role should be created. **If passing `iam_role_arn` this should be false, otherwise if you want to create the OIDC assumable IAM role provided by this module, you will need to specify the variable `cluster_oidc_issuer_url`.**"
   type        = bool
@@ -78,4 +112,3 @@ variable "cluster_oidc_issuer_url" {
   type        = string
   default     = "" # Use empty string instead of null because of the replace() that uses this variable.
 }
-


### PR DESCRIPTION
## Description of the changes

This PR adds a variable to set resources' limits and requests on the module components.

Having default values is good practice to prevent that our components could eventually starve other workloads on the cluster. However, these should probably be adapted in production clusters and are only a safeguard in case someone forgets to set them.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] EKS (AWS)