### PR TITLE
fix: re-set the EBS storage class as the default

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -76,11 +76,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
-
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Modules
 
@@ -154,7 +154,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.1.0"`
+Default: `"v3.4.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -250,6 +250,14 @@ Type: `string`
 
 Default: `""`
 
+==== [[input_default_storage_class]] <<input_default_storage_class,default_storage_class>>
+
+Description: Boolean to indicate if the EBS CSI driver should be the default storage class.
+
+Type: `bool`
+
+Default: `true`
+
 === Outputs
 
 The following outputs are exported:
@@ -280,9 +288,9 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_utils]] <<provider_utils,utils>> |>= 1
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_null]] <<provider_null,null>> |>= 3
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
+|[[provider_utils]] <<provider_utils,utils>> |>= 1
 |===
 
 = Modules
@@ -337,7 +345,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.1.0"`
+|`"v3.4.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>
@@ -433,6 +441,12 @@ object({
 |Cluster OIDC issuer URL used to create the OIDC assumable IAM role. This variable is required to create a IAM role if you set `create_role` as true.
 |`string`
 |`""`
+|no
+
+|[[input_default_storage_class]] <<input_default_storage_class,default_storage_class>>
+|Boolean to indicate if the EBS CSI driver should be the default storage class.
+|`bool`
+|`true`
 |no
 
 |===

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,9 @@
 locals {
   helm_values = [{
     "aws-ebs-csi-driver" = {
+      defaultStorageClass = {
+        enabled = var.default_storage_class
+      }
       controller = {
         serviceAccount = {
           annotations = {

--- a/variables.tf
+++ b/variables.tf
@@ -112,3 +112,10 @@ variable "cluster_oidc_issuer_url" {
   type        = string
   default     = "" # Use empty string instead of null because of the replace() that uses this variable.
 }
+
+variable "default_storage_class" {
+  description = "Boolean to indicate if the EBS CSI driver should be the default storage class."
+  type        = bool
+  default     = true
+  nullable    = false
+}


### PR DESCRIPTION
## Description of the changes

For reasons unknown to us, on the AWS side, the EBS storage class stopped being set as the default one automatically. I now found this attribute to fix that issue. I've also added a variable to customize it if required.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] EKS (AWS)
